### PR TITLE
HFE disk format support

### DIFF
--- a/src/ZXMAK2.Engine/Serializers/DiskLoadManager.cs
+++ b/src/ZXMAK2.Engine/Serializers/DiskLoadManager.cs
@@ -23,6 +23,7 @@ namespace ZXMAK2.Serializers
             AddSerializer(new QdiSerializer(diskImage));
             AddSerializer(new SclSerializer(diskImage));
             AddSerializer(new HobetaSerializer(diskImage));
+            AddSerializer(new HfeSerializer(diskImage));
 
             diskImage.LoadDisk += LoadDisk;
             diskImage.SaveDisk += SaveDisk;

--- a/src/ZXMAK2.Engine/Serializers/DiskSerializers/HfeSerializer.cs
+++ b/src/ZXMAK2.Engine/Serializers/DiskSerializers/HfeSerializer.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ZXMAK2.Dependency;
+using ZXMAK2.Host.Interfaces;
+using ZXMAK2.Model.Disk;
+
+
+namespace ZXMAK2.Serializers.DiskSerializers
+{
+    public class HfeSerializer : FormatSerializer
+    {
+        #region private data
+
+        // readonly byte[] MARK_C2 = new byte[] { 0x52, 0x24 };
+        readonly byte[] MARK_A1_ADDRESS = new byte[] { 0x44, 0x89, 0x44, 0x89, 0x44, 0x89, 0x55, 0x54 };
+        private const string HXCPICFE = "HXCPICFE"; // magic signature
+        
+        private DiskImage _diskImage;
+
+        #endregion
+
+
+        public HfeSerializer(DiskImage diskImage)
+        {
+            _diskImage = diskImage;
+        }
+
+
+        #region FormatSerializer
+
+        public override string FormatGroup => "Disk images";
+        public override string FormatName => "HxC emulator image";
+        public override string FormatExtension => "HFE";
+
+        public override bool CanDeserialize => true;
+        public override bool CanSerialize => true;
+
+        public override void Deserialize(Stream stream)
+        {
+            if (LoadFromStream(stream))
+            {
+                _diskImage.ModifyFlag = ModifyFlag.None;
+                _diskImage.Present = true;
+            }
+        }
+
+        public override void Serialize(Stream stream)
+        {
+            SaveToStream(stream);
+            _diskImage.ModifyFlag = ModifyFlag.None;
+        }
+
+        public override void SetSource(string fileName)
+        {
+            _diskImage.FileName = fileName;
+        }
+
+        public override void SetReadOnly(bool readOnly)
+        {
+            _diskImage.IsWP = readOnly;
+        }
+
+        #endregion
+
+        private bool LoadFromStream(Stream stream)
+        {
+            using (var reader = new BinaryReader(stream))
+            {
+                var signature = new string(reader.ReadChars(8));
+                if (signature != HXCPICFE)
+                {
+                    Locator.Resolve<IUserMessage>()
+                        .Error($"HFE loader\n\nInvalid HFE signature: {signature}");
+                    return false;
+                }
+
+                reader.ReadByte(); // format revision (ignore)
+                var numberOfTracks = reader.ReadByte();
+                var numberOfSides = reader.ReadByte();
+                var trackEncoding = reader.ReadByte();
+                
+                // We support only IBM MFM DD floppies (ISOIBM_MFM_ENCODING, which is 0)
+                if (trackEncoding != 0)
+                {
+                    Locator.Resolve<IUserMessage>()
+                        .Error($"HFE loader\n\nInvalid track encoding: {trackEncoding}");
+                    return false;
+                }
+                
+                _diskImage.SetPhysics(numberOfTracks, numberOfSides);
+                
+                // We read 12 bytes (8 + 1 + 1 + 1 + 1), so 500 is left until header end
+                reader.ReadBytes(500);
+                
+                // Now there is 'numberOfTracks' items with track pointers
+                var trackOffsets = new List<Tuple<ushort, ushort>>();
+                for (int _ = 0; _ < numberOfTracks; _++)
+                {
+                    var trackOffset = reader.ReadUInt16();
+                    var trackLen = reader.ReadUInt16();
+                    trackOffsets.Add(new Tuple<ushort, ushort>(trackOffset, trackLen));
+                }
+
+                // Put list in order of offset increment (most likely it already is)
+                trackOffsets = trackOffsets.OrderBy(t => t.Item1).ToList();
+                
+                // Where are we now in file? 512 bytes header + 4 bytes per each track
+                var currentPos = 512 + 2 * sizeof(UInt16) * numberOfTracks;
+
+                // Parse tracks according to the stored offsets and lengths
+                foreach (var tp in trackOffsets)
+                {
+                    var requiredPos = tp.Item1 * 512;
+                    if (currentPos > requiredPos)
+                    {
+                        Locator.Resolve<IUserMessage>().Error($"HFE loader\n\nInvalid file contents");
+                        return false;
+                    }
+
+                    // Fast forward to the track data
+                    reader.ReadBytes(requiredPos - currentPos);
+                    currentPos = requiredPos;
+
+                    var cylinderData = reader.ReadBytes(tp.Item2);
+                    currentPos += tp.Item2;
+                    
+                    // "Track data" consist of blocks (512b), where first half is side 0 and second half is side 1
+                    // So it is actually the interleaved cylinder data. We need to split it to two tracks.
+                    var trackBlocksCount = Convert.ToInt32(Math.Ceiling(tp.Item2 / 512f));
+                    var trackDataSide0 = new byte[256 * trackBlocksCount];
+                    var trackDataSide1 = new byte[256 * trackBlocksCount];
+                    for (int i = 0; i < trackBlocksCount; i++)
+                    {
+                        var block0 = cylinderData.Skip(512 * i).Take(256);
+                        var block1 = cylinderData.Skip(512 * i + 256).Take(256);
+
+                        var pos0 = 256 * i;
+                        var pos1 = pos0;
+
+                        foreach (var b in block0)
+                            trackDataSide0[pos0++] = b;
+                        
+                        foreach (var b in block1)
+                            trackDataSide1[pos1++] = b;
+                    }
+
+                    foreach (var track in new[] { trackDataSide0, trackDataSide1 }.Take(numberOfSides))
+                    {
+                        var mfm = new MfmCoder(track);
+
+                        // Detect if clock is odd or even bit
+                        var a1Pos = mfm.Find(MARK_A1_ADDRESS);
+
+                        // Is track formatted? (otherwise there are no sector headers and we'll be unable to find A1)
+                        if (a1Pos != -1)
+                        {
+                            // Skip 1 bit if there is a garbage ahead of the first clock
+                            if ((a1Pos & 1) == 1)
+                                mfm.ReadBit();
+
+                            var dataAndClock = mfm.SplitDataAndClock();
+                            var data = dataAndClock.Item1;
+                            var clock = dataAndClock.Item2;
+
+                            // Now a1Pos is pointer in bytes
+                            a1Pos >>= 4;
+
+                            var trackNumber = data[a1Pos + 4];
+                            var sideNumber = data[a1Pos + 5];
+                            
+                            // Now we should convert full array of clock bits to the reduced one, where the only thing,
+                            // which is stored, is a sync flag for data byte. 0 when the byte is normal and 1 if byte is
+                            // C2/A1 mark
+
+                            var reducedClock = MfmCoder.ReduceClockArray(data, clock);
+                            
+                            _diskImage.GetTrackImage(trackNumber, sideNumber).AssignImage(data, reducedClock);
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private void SaveToStream(Stream stream)
+        {
+            using (var writer = new BinaryWriter(stream))
+            {
+                writer.Write(Encoding.ASCII.GetBytes(HXCPICFE));
+                writer.Write((byte)0); // format revision 0
+                writer.Write((byte)_diskImage.CylynderCount);
+                writer.Write((byte)_diskImage.SideCount);
+                writer.Write((byte)0); // ISOIBM_MFM_ENCODING
+                writer.Write((UInt16)250); // Bit Rate in kbps
+                writer.Write((UInt16)300); // Rotation per minute
+                writer.Write((byte)0); // IBMPC_DD_FLOPPYMOD
+                writer.Write((byte)0); // dnu
+                writer.Write((short)1); // Track lookup table is at 512 bytes
+                
+                // 20 bytes written. We need to append padding to 512 bytes
+                
+                var remainingHeaderData = new byte[512 - 20];
+                writer.Write(remainingHeaderData);
+
+                var hfeTracks = new List<byte[]>();
+                
+                for (int cyl = 0; cyl < _diskImage.CylynderCount; cyl++)
+                {
+                    var track0 = _diskImage.GetTrackImage(cyl, 0);
+                    var track1 = _diskImage.SideCount > 1 ? _diskImage.GetTrackImage(cyl, 1) : null;
+
+                    var track0Data = track0.RawImage[0];
+                    var track0Clock = MfmCoder.ExpandClockArray(track0Data, track0.RawImage[1]);
+                    var track0Mfm = MfmCoder.CombineDataAndClock(track0Data, track0Clock);
+
+                    byte[] track1Mfm;
+                    if (track1 != null)
+                    {
+                        var track1Data = track1.RawImage[0];
+                        var track1Clock = MfmCoder.ExpandClockArray(track1Data, track1.RawImage[1]);
+                        track1Mfm = MfmCoder.CombineDataAndClock(track1Data, track1Clock);
+                    }
+                    else
+                    {
+                        // Even for single sided drives ne need to follow the track format, where 2nd side is present
+                        // So replacing it with 0
+                        track1Mfm = new byte[track0Mfm.Length];
+                    }
+                    
+                    var trackBlocksCount = Convert.ToInt32(Math.Ceiling(Math.Max(track0Mfm.Length, track1Mfm.Length) / 256f));
+                    var hfeTrackData = new byte[trackBlocksCount * 512];
+                    for (int i = 0; i < trackBlocksCount; i++)
+                    {
+                        track0Mfm.Skip(i * 256).Take(256).ToArray().CopyTo(hfeTrackData, i * 512);
+                        track1Mfm.Skip(i * 256).Take(256).ToArray().CopyTo(hfeTrackData, i * 512 + 256);
+                    }
+                    hfeTracks.Add(hfeTrackData);
+                }
+
+                var trackOffsetsDataSize = hfeTracks.Count * 2 * sizeof(UInt16);
+                var trackOffset512BlockSize = Convert.ToInt32(Math.Ceiling(trackOffsetsDataSize / 512f));
+
+                var offset = 1 + trackOffset512BlockSize;
+                foreach (var hfeTrack in hfeTracks)
+                {
+                    writer.Write((UInt16)offset);
+                    writer.Write((UInt16)hfeTrack.Length);
+                    offset += hfeTrack.Length / 512;
+                }
+                
+                // Fill gap to next 512 byte block
+                writer.Write(new byte[trackOffset512BlockSize * 512 - trackOffsetsDataSize]);
+                
+                foreach (var hfeTrack in hfeTracks)
+                    writer.Write(hfeTrack);
+            }
+        }
+    }
+}

--- a/src/ZXMAK2.Engine/ZXMAK2.Engine.csproj
+++ b/src/ZXMAK2.Engine/ZXMAK2.Engine.csproj
@@ -91,6 +91,7 @@
     <Compile Include="RzxHandler.cs" />
     <Compile Include="Serializers\DiskLoadManager.cs" />
     <Compile Include="Serializers\DiskSerializers\FdiSerializer.cs" />
+    <Compile Include="Serializers\DiskSerializers\HfeSerializer.cs" />
     <Compile Include="Serializers\DiskSerializers\HobetaSerializer.cs" />
     <Compile Include="Serializers\DiskSerializers\ImgSerializer.cs" />
     <Compile Include="Serializers\DiskSerializers\LzssHuffmanStream.cs" />

--- a/src/ZXMAK2.Model.Disk/MfmCoder.cs
+++ b/src/ZXMAK2.Model.Disk/MfmCoder.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ZXMAK2.Model.Disk
+{
+    public class MfmCoder
+    {
+        private readonly BitArray _data;
+        private int _pos = 0;
+
+        public MfmCoder(byte[] data)
+        {
+            _data = new BitArray(data);
+        }
+
+        public byte ReadBit()
+        {
+            if (_pos >= _data.Length)
+                return 0;
+
+            return (byte)(_data[_pos++] ? 1 : 0);
+        }
+
+        public int Find(byte[] pattern)
+        {
+            var window = BitsToBytes(_data, _pos, pattern.Length, true).ToArray();
+            var srcPos = _pos + pattern.Length * 8;
+
+            bool found = false;
+            while (!(found = pattern.SequenceEqual(window)) && srcPos != _data.Length)
+            {
+                var msb = (byte)(_data[srcPos++] ? 1 : 0);
+                for (var i = pattern.Length - 1; i >= 0; i--)
+                {
+                    var newMsb = (byte)((window[i] & 0x80) >> 7);
+                    window[i] <<= 1;
+                    window[i] |= msb;
+                    msb = newMsb;
+                }
+            }
+
+            if (found)
+                return srcPos - pattern.Length * 8;
+
+            return -1;
+        }
+        
+        private static IEnumerable<byte> BitsToBytes(BitArray bits, int startPos = 0, int byteCount = -1, bool msb = false)
+        {
+            int bitCount = 7;
+            int outByte = 0;
+
+            var maxBit = byteCount > 0 ? (startPos + 8 * byteCount) : bits.Length;
+            for (int i = startPos; i < maxBit; i++)
+            {
+                if (bits[i])
+                    outByte |= msb ? 1 << bitCount : 1 << (7 - bitCount);
+                if (bitCount == 0)
+                {
+                    yield return (byte) outByte;
+                    bitCount = 8;
+                    outByte = 0;
+                }
+                bitCount--;
+            }
+            // Last partially decoded byte
+            if (bitCount < 7)
+                yield return (byte) outByte;
+        }
+
+        public Tuple<byte[], byte[]> SplitDataAndClock()
+        {
+            var length = Convert.ToInt32((_data.Length - _pos) / 2f);
+            var data = new BitArray(length);
+            var clock = new BitArray(length);
+
+            var outputPos = 0;
+            for (int i = _pos; i + 1 < _data.Length; i+=2)
+            {
+                clock[outputPos] = _data[i];
+                data[outputPos] = _data[i + 1];
+                outputPos++;
+            }
+
+            var bytesCount = Convert.ToInt32(Math.Ceiling(data.Length / 8f));
+            var dataBytes = BitsToBytes(data, 0, bytesCount, true).ToArray();
+            var clockBytes = BitsToBytes(clock, 0, bytesCount, true).ToArray();
+
+            return new Tuple<byte[], byte[]>(dataBytes, clockBytes);
+        }
+
+        public static byte[] CombineDataAndClock(byte[] data, byte[] clock)
+        {
+            var dataArray = new BitArray(data);
+            var clockArray = new BitArray(clock);
+            var result = new BitArray(dataArray.Length * 2);
+
+            for (int i = 0; i < dataArray.Length; i++)
+            {
+                var pos = (i & ~7) | (7 - (i & 7));
+                result[2 * i] = clockArray[pos];
+                result[2 * i + 1] = dataArray[pos];
+            }
+
+            return BitsToBytes(result).ToArray();
+        }
+        
+        public static byte[] GenerateMfmClock(byte[] data)
+        {
+            var clock = new byte[data.Length];
+            var dataBits = new BitArray(data);
+            var clockBits = new BitArray(clock);
+
+            var prev = false;
+            for (int i = 0; i < dataBits.Length; i++)
+            {
+                // Since first bit in array is 0-th bit of first byte
+                var pos = (i & ~7) | (7 - (i & 7));
+                
+                var dataBit = dataBits[pos];
+                clockBits[pos] = !dataBit && !prev;
+                prev = dataBit;
+            }
+
+            return BitsToBytes(clockBits).ToArray();
+        }
+        
+        public static byte[] ReduceClockArray(byte[] data, byte[] clock)
+        {
+            // Calculate correct MFM clock for a data bytes
+            var normalMfm = GenerateMfmClock(data);
+
+            var result = new BitArray(data.Length);
+
+            // And compare it with what we have. Difference will be at C2/A1 marks
+            for (int i = 0; i < data.Length; i++)
+                result[i] = clock[i] != normalMfm[i];
+
+            return BitsToBytes(result).ToArray();
+        }
+
+        public static byte[] ExpandClockArray(byte[] data, byte[] clock)
+        {
+            var resultClock = GenerateMfmClock(data);
+            Func<int, bool> rawTestClock = pos => (clock[pos / 8] & (1 << (pos & 7))) != 0;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if ((data[i] == 0xA1 || data[i] == 0xC2) && rawTestClock(i))
+                {
+                    if (data[i] == 0xA1) // fix clock for "special" A1
+                        resultClock[i] ^= (1 << 2);
+                    else // ...or for C2
+                        resultClock[i] ^= (1 << 3);
+                }
+            }
+
+            return resultClock;
+        }
+    }
+}

--- a/src/ZXMAK2.Model.Disk/ZXMAK2.Model.Disk.csproj
+++ b/src/ZXMAK2.Model.Disk/ZXMAK2.Model.Disk.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DiskImage.cs" />
+    <Compile Include="MfmCoder.cs" />
     <Compile Include="ModifyFlag.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sector.cs" />


### PR DESCRIPTION
HFE is used by HxC emulator and greaseweazle disk dumper, and it's pretty useful to test files in emulator sometimes.
Also may be used to convert TR-DOS/IS-DOS/whatever disk images to HFE.